### PR TITLE
Add network policy to lock this down by default.

### DIFF
--- a/k8s/network-policy.yaml
+++ b/k8s/network-policy.yaml
@@ -13,6 +13,9 @@ spec:
     - namespaceSelector:
         matchLabels:
           name: namespace-goes-here
+    - podSelector:
+        matchLabels:
+          app: pod-that-can-talk-to-my-app
     ports:
     - port: 2025
       protocol: TCP

--- a/k8s/network-policy.yaml
+++ b/k8s/network-policy.yaml
@@ -12,10 +12,7 @@ spec:
   - from:
     - namespaceSelector:
         matchLabels:
-          name: namespace-goes-here
-    - podSelector:
-        matchLabels:
-          app: pod-that-can-talk-to-my-app
+          name: policy-reporter
     ports:
     - port: 2025
       protocol: TCP

--- a/k8s/network-policy.yaml
+++ b/k8s/network-policy.yaml
@@ -1,0 +1,25 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  labels:
+    app: relay
+    version: v1
+    env: production
+    kind: web
+  name: relay
+spec:
+  ingress:
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          name: namespace-goes-here
+    ports:
+    - port: 2025
+      protocol: TCP
+  podSelector:
+    matchLabels:
+      app: relay
+      version: v1
+      env: production
+  policyTypes:
+  - Ingress

--- a/k8s/service.yaml
+++ b/k8s/service.yaml
@@ -1,6 +1,11 @@
 apiVersion: v1
 kind: Service
 metadata:
+  labels:
+    app: relay
+    version: v1
+    env: production
+    kind: web
   name: relay
 spec:
   selector:

--- a/kustomization.yaml
+++ b/kustomization.yaml
@@ -4,3 +4,4 @@ kind: Kustomization
 resources:
 - k8s/service.yaml
 - k8s/deploy.yaml
+- k8s/network-policy.yaml


### PR DESCRIPTION
Would rather not have an open SMTP relay - this way we can only allow SMTP connections from whatever namespace we decide is allowed.