### PR TITLE
Fix network policy.

### DIFF
--- a/k8s/network-policy.yaml
+++ b/k8s/network-policy.yaml
@@ -3,23 +3,18 @@ kind: NetworkPolicy
 metadata:
   labels:
     app: relay
-    version: v1
-    env: production
-    kind: web
   name: relay
 spec:
-  ingress:
-  - from:
-    - namespaceSelector:
-        matchLabels:
-          name: policy-reporter
-    ports:
-    - port: 2025
-      protocol: TCP
   podSelector:
     matchLabels:
       app: relay
-      version: v1
-      env: production
   policyTypes:
-  - Ingress
+    - Ingress
+  ingress:
+    - from:
+      - namespaceSelector:
+          matchLabels:
+            kubernetes.io/metadata.name: policy-reporter
+      ports:
+      - port: 2025
+        protocol: TCP


### PR DESCRIPTION
The network policy was blocking SMTP requests - so no emails were getting through:

![Screen Shot 2023-01-03 at 10 54 14 AM](https://user-images.githubusercontent.com/5176/210435768-82d2034c-dc00-41c1-b109-23591706a4b0.png)

Found this link on the kubernetes site:

https://kubernetes.io/docs/concepts/services-networking/network-policies/#targeting-a-namespace-by-its-name

Tested this extensively and made sure it did what I wanted it to do:

```bash
(⎈ |sre-prod:policy-reporter)➜  ~ kubectl run multitool --image=wbitt/network-multitool:alpine-extra -i --tty --rm -n sre -- sh
If you don't see a command prompt, try pressing enter.
/ # telnet relay.policy-reporter.svc.cluster.local 2025
^C
/ # exit
Session ended, resume using 'kubectl attach multitool -c multitool -i -t' command when the pod is running
pod "multitool" deleted
(⎈ |sre-prod:policy-reporter)➜  ~ kubectl run multitool --image=wbitt/network-multitool:alpine-extra -i --tty --rm -n policy-reporter -- sh
If you don't see a command prompt, try pressing enter.
/ # telnet relay 2025
Connected to relay
220 mailgun.dapperlabs.com ESMTP Service Ready
^C
Console escape. Commands are:

 l	go to line mode
 c	go to character mode
 z	suspend telnet
 e	exit telnet
/ # exit
Session ended, resume using 'kubectl attach multitool -c multitool -i -t' command when the pod is running
pod "multitool" deleted
```