### PR TITLE
Better resource limits - less CPU throttling.

### DIFF
--- a/k8s/deploy.yaml
+++ b/k8s/deploy.yaml
@@ -61,10 +61,10 @@ spec:
               value: mailgun.dapperlabs.com
           resources:
             requests:
-              cpu: "500m"
+              cpu: "250m"
               memory: "16Mi"
             limits:
-              cpu: "1000m"
+              cpu: "500m"
               memory: "32Mi"
           readinessProbe:
             httpGet:

--- a/k8s/deploy.yaml
+++ b/k8s/deploy.yaml
@@ -61,11 +61,11 @@ spec:
               value: mailgun.dapperlabs.com
           resources:
             requests:
-              cpu: "10m"
-              memory: "24Mi"
+              cpu: "500m"
+              memory: "16Mi"
             limits:
-              cpu: "20m"
-              memory: "48Mi"
+              cpu: "1000m"
+              memory: "32Mi"
           readinessProbe:
             httpGet:
               path: /


### PR DESCRIPTION
Took a look at how much throttling `relay` was going - and it was more than I expected:

![Screenshot 2023-02-16 at 2 53 04 PM](https://user-images.githubusercontent.com/5176/219495394-9552c97c-bcb3-4958-a074-2c91c8886db3.png)

Double checked this against another tool to make sure:

![Screenshot 2023-02-16 at 2 54 46 PM](https://user-images.githubusercontent.com/5176/219495677-25cec0fb-5152-4541-b609-3fc7e33879fd.png)

TLDR: The previous limits were just not even close to accurate - so there was a bunch of throttling.

Trying a lower limit than this PR has - will update the PR if I determine there's minimal throttling then too.